### PR TITLE
Adding notes about snapraid detecting moved files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ This container is configured using two files `snapraid.conf` and `snapraid-runne
 
 It is based on phusion-baseimage with ssh removed, for shell access whilst the container is running do `docker exec -it snapraid /bin/bash`.
 
+### Detecting move operations
+You'll probably notice when snapraid runs it gives a warning like `WARNING! UUID is unsupported for disks` and it may not detect moved files. Instead it seems them as copied and removed. In order to detect the file moves you can run with the following additional paramters.
+
+```
+--privileged --mount type=bind,source=/dev/disk,target=/dev/disk
+```
+
+* `--privileged` will share all your devices (ie `/dev/sdb`, `/dev/sdb1`, etc) with your container. Alternatively, you could probably use something like `--device /dev/sdb:/dev/sdb --device /dev/sdb1:/dev/sdb1`, but you'd need to do it for each drive you have setup.
+* `--mount type=bind,source=/dev/disk,target=/dev/disk` mounts the disk listing into the container, so snapraid can run something like `ls /dev/disk/by-uuid` to get a list of all the disks by UUID
+
 ### User / Group Identifiers
 
 **TL;DR** - The `PGID` and `PUID` values set the user / group you'd like your container to 'run as' to the host OS. This can be a user you've created or even root (not recommended).


### PR DESCRIPTION
I found when running any of these snapraid containers, snapraid spits out the following message:

```
WARNING! UUID is unsupported for disks: 'd1', 'd2', 'd3'. Not using inodes to detect move operations.
```

And what I found was that when files did move, sure enough it did not see them as moved, but instead as removed and added. For me, I run my snapraid with a deletion limit of 0, meaning if any file is deleted, I want to review it. My data is pretty static, so its not often that files are deleted. They do occasionally move from one disk to another which is fine. So I figured out what's required to get it to detect that and this is what I came up with and figured it should be added to the readme.

